### PR TITLE
Updated Wisconsin Matching Keywords

### DIFF
--- a/imagesof_bot.py
+++ b/imagesof_bot.py
@@ -687,7 +687,12 @@ def search_for_places(r):
     #wisconsin
         swim(r,
             submission = post,
-            goodregex = r"(\bwisconsin\b|\bwisc\b|\bgreen bay\b(?!.*packers)|\bmilwaukee\b(?!.*brewers)|\bnew glarus\b|\bspotted cow\b|\buw oshkosh\b|\buw madison\b|\bmsoe\b|\bsummerfest\b|\bdoor county\b|\bfox valley\b|\blake winnebago\b|\bhouse on the rock\b|\bcave on the mounds\b|\bharley-davidson museum\b|\bdevil's lake state park\b|\bkettle moraine\b|\bsturgeon bay\b|\bappleton\b|\beau claire\b|\bminocqua\b|\beagle river\b|\begg harbor\b|\bstevens point\b|\bfond du lac\b|\blambeau field\b|\beaa airventure\b|\beaa air venture\b|\bmiller park\b|\bpabst theater\b|\balpine valley\b|\bEAA\b.*\bOshkosh\b|\bOshkosh\b.*\bEAA\b|\bUW\b.*\b(Oshkosh|Madison|)\b|\bMadison\b.*\bWI.*\b)",
+            goodregex = r"(\bwisconsin\b|\bwisc\b|\bgreen bay\b(?!.*packers)|\bmilwaukee\b(?!.*brewers)|\bnew glarus\b|\bspotted cow\b|\bmsoe\b|\bsummerfest\b|\bdoor county\b|\bfox valley\b|\blake winnebago\b|\bhouse on the rock\b|\bcave on the mounds\b|\bharley-davidson museum\b|\bdevil's lake state park\b|\bkettle moraine\b|\bsturgeon bay\b|\bappleton\b|\beau claire\b|\bminocqua\b|\beagle river\b|\begg harbor\b|\bstevens point\b|\bfond du lac\b|\blambeau field\b|\beaa airventure\b|\beaa air venture\b|\bmiller park\b|\bpabst theater\b|\balpine valley\b|\beaa\b.*\boshkosh\b|\boshkosh\b.*\beaa\b|\buw\b.*\b(oshkosh|madison|)\b|\bmadison\b.*\bwi.*\b)",
+            badregex = r"(\bwisconsin ave\b|\bwisconsin blvd\b)",
+            postinto = 'imagesofwisconsin',
+            getfromthese = {'wisconsin'}
+            )
+
             badregex = r"(\bwisconsin ave\b|\bwisconsin blvd\b)",
             postinto = 'imagesofwisconsin',
             getfromthese = {'wisconsin'}

--- a/imagesof_bot.py
+++ b/imagesof_bot.py
@@ -692,11 +692,7 @@ def search_for_places(r):
             postinto = 'imagesofwisconsin',
             getfromthese = {'wisconsin'}
             )
-
-            badregex = r"(\bwisconsin ave\b|\bwisconsin blvd\b)",
-            postinto = 'imagesofwisconsin',
-            getfromthese = {'wisconsin'}
-            )
+            
     #wyoming
         swim(r,
             submission = post,

--- a/imagesof_bot.py
+++ b/imagesof_bot.py
@@ -687,7 +687,8 @@ def search_for_places(r):
     #wisconsin
         swim(r,
             submission = post,
-            goodregex = r"(\bwisconsin\b)",
+            goodregex = r"(\bwisconsin\b|\bwisc\b|\bgreen bay\b|\bmilwaukee\b|\bnew glarus\b|\bspotted cow\b|\buw oshkosh\b|\buw madison\b|\bmsoe\b|\bsummerfest\b|\bdoor county\b|\bfox valley\b|\blake winnebago\b|\bhouse on the rock\b|\bcave on the mounds\b|\bharley-davidson museum\b|\bdevil's lake state park\b|\bkettle moraine\b|\bsturgeon bay\b|\bappleton\b|\beau claire\b|\bminocqua\b|\beagle river\b|\begg harbor\b|\bstevens point\b|\bfond du lac\b|\blambeau field\b|\beaa airventure\b|\beaa air venture\b|\bmiller park\b|\bpabst theater\b|\balpine valley)",
+            badregex = r"(\bgreen bay packers\b|\bmilwaukee brewers\b|\bwisconsin ave\b|\bwisconsin blvd\b)",
             postinto = 'imagesofwisconsin',
             getfromthese = {'wisconsin'}
             )

--- a/imagesof_bot.py
+++ b/imagesof_bot.py
@@ -688,7 +688,7 @@ def search_for_places(r):
         swim(r,
             submission = post,
             goodregex = r"(\bwisconsin\b|\bwisc\b|\bgreen bay\b(?!.*packers)|\bmilwaukee\b(?!.*brewers)|\bnew glarus\b|\bspotted cow\b|\buw oshkosh\b|\buw madison\b|\bmsoe\b|\bsummerfest\b|\bdoor county\b|\bfox valley\b|\blake winnebago\b|\bhouse on the rock\b|\bcave on the mounds\b|\bharley-davidson museum\b|\bdevil's lake state park\b|\bkettle moraine\b|\bsturgeon bay\b|\bappleton\b|\beau claire\b|\bminocqua\b|\beagle river\b|\begg harbor\b|\bstevens point\b|\bfond du lac\b|\blambeau field\b|\beaa airventure\b|\beaa air venture\b|\bmiller park\b|\bpabst theater\b|\balpine valley\b|\bEAA\b.*\bOshkosh\b|\bOshkosh\b.*\bEAA\b|\bUW\b.*\b(Oshkosh|Madison|)\b|\bMadison\b.*\bWI.*\b)",
-            badregex = r"(\bgreen bay packers\b|\bmilwaukee brewers\b|\bwisconsin ave\b|\bwisconsin blvd\b)",
+            badregex = r"(\bwisconsin ave\b|\bwisconsin blvd\b)",
             postinto = 'imagesofwisconsin',
             getfromthese = {'wisconsin'}
             )

--- a/imagesof_bot.py
+++ b/imagesof_bot.py
@@ -687,8 +687,8 @@ def search_for_places(r):
     #wisconsin
         swim(r,
             submission = post,
-            goodregex = r"(\bwisconsin\b|\bwisc\b|\bgreen bay\b(?!.*packers)|\bmilwaukee\b(?!.*brewers)|\bnew glarus\b|\bspotted cow\b|\bmsoe\b|\bsummerfest\b|\bdoor county\b|\bfox valley\b|\blake winnebago\b|\bhouse on the rock\b|\bcave on the mounds\b|\bharley-davidson museum\b|\bdevil's lake state park\b|\bkettle moraine\b|\bsturgeon bay\b|\bappleton\b|\beau claire\b|\bminocqua\b|\beagle river\b|\begg harbor\b|\bstevens point\b|\bfond du lac\b|\blambeau field\b|\beaa airventure\b|\beaa air venture\b|\bmiller park\b|\bpabst theater\b|\balpine valley\b|\beaa\b.*\boshkosh\b|\boshkosh\b.*\beaa\b|\buw\b.*\b(oshkosh|madison|)\b|\bmadison\b.*\bwi.*\b)",
-            badregex = r"(\bwisconsin ave\b|\bwisconsin blvd\b)",
+            goodregex = r"(\bwisconsin\b|\bwisc\b|\bgreen bay\b(?!.packers)|\bmilwaukee\b(?!.brewers)|\bnew glarus\b|\bspotted cow\b|\bmsoe\b|\bsummerfest\b|\bdoor county\b|\bfox valley\b|\blake winnebago\b|\bhouse on the rock\b|\bcave on the mound.?\b|\bharley.davidson museum\b|\bdevil's lake state park\b|\bkettle moraine\b|\bsturgeon bay\b|\bappleton\b|\beau claire\b|\bminocqua\b|\beagle river\b|\begg harbor\b|\bstevens point\b|\bfond du lac\b|\blambeau field\b|\beaa airventure\b|\beaa air venture\b|\bmiller park\b|\bpabst theater\b|\balpine valley\b|\beaa\b.*\boshkosh\b|\boshkosh\b.*\beaa\b|\b(uw.oshkosh|uw.madison)\b|\bmadison\b.*\bwi.*\b)",
+            badregex = r"(\bwisconsin ave.*\b|\bwisconsin blvd\b)",
             postinto = 'imagesofwisconsin',
             getfromthese = {'wisconsin'}
             )

--- a/imagesof_bot.py
+++ b/imagesof_bot.py
@@ -687,7 +687,7 @@ def search_for_places(r):
     #wisconsin
         swim(r,
             submission = post,
-            goodregex = r"(\bwisconsin\b|\bwisc\b|\bgreen bay\b|\bmilwaukee\b|\bnew glarus\b|\bspotted cow\b|\buw oshkosh\b|\buw madison\b|\bmsoe\b|\bsummerfest\b|\bdoor county\b|\bfox valley\b|\blake winnebago\b|\bhouse on the rock\b|\bcave on the mounds\b|\bharley-davidson museum\b|\bdevil's lake state park\b|\bkettle moraine\b|\bsturgeon bay\b|\bappleton\b|\beau claire\b|\bminocqua\b|\beagle river\b|\begg harbor\b|\bstevens point\b|\bfond du lac\b|\blambeau field\b|\beaa airventure\b|\beaa air venture\b|\bmiller park\b|\bpabst theater\b|\balpine valley\b|\bEAA\b.*\bOshkosh\b|\bOshkosh\b.*\bEAA\b|\bUW\b.*\b(Oshkosh|Madison|)\b|\bMadison\b.*\bWI.*\b)",
+            goodregex = r"(\bwisconsin\b|\bwisc\b|\bgreen bay\b(?!.*packers)|\bmilwaukee\b(?!.*brewers)|\bnew glarus\b|\bspotted cow\b|\buw oshkosh\b|\buw madison\b|\bmsoe\b|\bsummerfest\b|\bdoor county\b|\bfox valley\b|\blake winnebago\b|\bhouse on the rock\b|\bcave on the mounds\b|\bharley-davidson museum\b|\bdevil's lake state park\b|\bkettle moraine\b|\bsturgeon bay\b|\bappleton\b|\beau claire\b|\bminocqua\b|\beagle river\b|\begg harbor\b|\bstevens point\b|\bfond du lac\b|\blambeau field\b|\beaa airventure\b|\beaa air venture\b|\bmiller park\b|\bpabst theater\b|\balpine valley\b|\bEAA\b.*\bOshkosh\b|\bOshkosh\b.*\bEAA\b|\bUW\b.*\b(Oshkosh|Madison|)\b|\bMadison\b.*\bWI.*\b)",
             badregex = r"(\bgreen bay packers\b|\bmilwaukee brewers\b|\bwisconsin ave\b|\bwisconsin blvd\b)",
             postinto = 'imagesofwisconsin',
             getfromthese = {'wisconsin'}

--- a/imagesof_bot.py
+++ b/imagesof_bot.py
@@ -687,7 +687,7 @@ def search_for_places(r):
     #wisconsin
         swim(r,
             submission = post,
-            goodregex = r"(\bwisconsin\b|\bwisc\b|\bgreen bay\b|\bmilwaukee\b|\bnew glarus\b|\bspotted cow\b|\buw oshkosh\b|\buw madison\b|\bmsoe\b|\bsummerfest\b|\bdoor county\b|\bfox valley\b|\blake winnebago\b|\bhouse on the rock\b|\bcave on the mounds\b|\bharley-davidson museum\b|\bdevil's lake state park\b|\bkettle moraine\b|\bsturgeon bay\b|\bappleton\b|\beau claire\b|\bminocqua\b|\beagle river\b|\begg harbor\b|\bstevens point\b|\bfond du lac\b|\blambeau field\b|\beaa airventure\b|\beaa air venture\b|\bmiller park\b|\bpabst theater\b|\balpine valley)",
+            goodregex = r"(\bwisconsin\b|\bwisc\b|\bgreen bay\b|\bmilwaukee\b|\bnew glarus\b|\bspotted cow\b|\buw oshkosh\b|\buw madison\b|\bmsoe\b|\bsummerfest\b|\bdoor county\b|\bfox valley\b|\blake winnebago\b|\bhouse on the rock\b|\bcave on the mounds\b|\bharley-davidson museum\b|\bdevil's lake state park\b|\bkettle moraine\b|\bsturgeon bay\b|\bappleton\b|\beau claire\b|\bminocqua\b|\beagle river\b|\begg harbor\b|\bstevens point\b|\bfond du lac\b|\blambeau field\b|\beaa airventure\b|\beaa air venture\b|\bmiller park\b|\bpabst theater\b|\balpine valley\b|\bEAA\b.*\bOshkosh\b|\bOshkosh\b.*\bEAA\b|\bUW\b.*\b(Oshkosh|Madison|)\b|\bMadison\b.*\bWI.*\b)",
             badregex = r"(\bgreen bay packers\b|\bmilwaukee brewers\b|\bwisconsin ave\b|\bwisconsin blvd\b)",
             postinto = 'imagesofwisconsin',
             getfromthese = {'wisconsin'}


### PR DESCRIPTION
Match Keyword list:
- wisconsin
- wisc
- green bay (but not `green bay packers`)
- milwaukee (but not `milwaukee brewers`)
- new glarus 
- spotted cow
- MSOE (acronym of Milwaukee School of Engineering) 
- summerfest 
- door county
- fox valley
- lake winnebago 
- house on the rock 
- cave on the mound[s] 
- harley[-]davidson museum
- devil's lake state park
- kettle moraine
- sturgeon bay
- appleton
- eau claire
- minocqua
- eagle river
- egg harbor
- stevens point
- fond du lac
- lambeau field 
- EAA AirVenture | EAA Air Venture | EAA [*] Oshkosh | Oshkosh [*] EAA
- miller park
- pabst theater 
- alpine valley
- uw[.]oshkosh
- uw[.]madison
- madison [*] WI

Tweaked the negative lookaheads (as per amici's feedback). 

See http://www.regexr.com/3d9og for regex test examples.
