### PR TITLE
KwaZulu Natal is related to Africa, not Brazil

### DIFF
--- a/images_of/data/settings.toml
+++ b/images_of/data/settings.toml
@@ -1660,6 +1660,7 @@ search = [
 ignore = [
     'bsalvador dal(i|í)',
     'el salvador',
+    'kwa(-| )zulu(-| )natal',
 ]
 whitelist = [
     'alagoas',


### PR DESCRIPTION
Results: https://www.reddit.com/user/amici_ursi/m/imagesofplaces/search?q=KwaZulu&restrict_sr=on&sort=relevance&t=all&feature=legacy_search

Please check if the all three combinations have been included.

Between three words - Kwa, Zulu and Natal, they can be combined or have a space or have a hyphen.